### PR TITLE
feat: upgrade Android SDK to 0.1.2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -127,5 +127,5 @@ dependencies {
   // noinspection GradleDynamicVersion
   api 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation "ai.proba.probasdk:probasdk:0.1.1"
+  implementation "ai.proba.probasdk:probasdk:0.1.2"
 }


### PR DESCRIPTION
Обновил Android SDK на версию 0.1.2.
В данной версии исправлена [проблема работы с debug-меню](https://github.com/proba-ai/proba-sdk-android/issues/5).